### PR TITLE
Added headers and topic exchange types

### DIFF
--- a/rabbitmq-transport/src/main/java/com/esri/geoevent/transport/rabbitmq/RabbitMQExchange.java
+++ b/rabbitmq-transport/src/main/java/com/esri/geoevent/transport/rabbitmq/RabbitMQExchange.java
@@ -33,7 +33,7 @@ import com.esri.ges.util.Validator;
 
 enum RabbitMQExchangeType
 {
-  direct, fanout
+  direct, fanout, headers, topic
 }
 
 public class RabbitMQExchange implements Validatable

--- a/rabbitmq-transport/src/main/java/com/esri/geoevent/transport/rabbitmq/RabbitMQInboundTransportDefinition.java
+++ b/rabbitmq-transport/src/main/java/com/esri/geoevent/transport/rabbitmq/RabbitMQInboundTransportDefinition.java
@@ -59,6 +59,8 @@ public class RabbitMQInboundTransportDefinition extends TransportDefinitionBase
       List<LabeledValue> exchangeTypeAllowedValues = new ArrayList<LabeledValue>();
       exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.direct.toString(), RabbitMQExchangeType.direct.toString()));
       exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.fanout.toString(), RabbitMQExchangeType.fanout.toString()));
+      exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.headers.toString(), RabbitMQExchangeType.headers.toString()));
+      exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.topic.toString(), RabbitMQExchangeType.topic.toString()));
       propertyDefinitions.put("exchangeType", new PropertyDefinition("exchangeType", PropertyType.String, RabbitMQExchangeType.direct.toString(), "${com.esri.geoevent.transport.rabbitmq-transport.TRANSPORT_EXCHANGE_TYPE_LBL}", "${com.esri.geoevent.transport.rabbitmq-transport.TRANSPORT_EXCHANGE_TYPE_DESC}", true, false, exchangeTypeAllowedValues));
 
       List<LabeledValue> exchangeDurabilityAllowedValues = new ArrayList<LabeledValue>();

--- a/rabbitmq-transport/src/main/java/com/esri/geoevent/transport/rabbitmq/RabbitMQOutboundTransportDefinition.java
+++ b/rabbitmq-transport/src/main/java/com/esri/geoevent/transport/rabbitmq/RabbitMQOutboundTransportDefinition.java
@@ -59,6 +59,8 @@ public class RabbitMQOutboundTransportDefinition extends TransportDefinitionBase
       List<LabeledValue> exchangeTypeAllowedValues = new ArrayList<LabeledValue>();
       exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.direct.toString(), RabbitMQExchangeType.direct.toString()));
       exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.fanout.toString(), RabbitMQExchangeType.fanout.toString()));
+      exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.headers.toString(), RabbitMQExchangeType.headers.toString()));
+      exchangeTypeAllowedValues.add(new LabeledValue(RabbitMQExchangeType.topic.toString(), RabbitMQExchangeType.topic.toString()));
       propertyDefinitions.put("exchangeType", new PropertyDefinition("exchangeType", PropertyType.String, RabbitMQExchangeType.direct.toString(), "${com.esri.geoevent.transport.rabbitmq-transport.TRANSPORT_EXCHANGE_TYPE_LBL}", "${com.esri.geoevent.transport.rabbitmq-transport.TRANSPORT_EXCHANGE_TYPE_DESC}", true, false, exchangeTypeAllowedValues));
 
       List<LabeledValue> exchangeDurabilityAllowedValues = new ArrayList<LabeledValue>();


### PR DESCRIPTION
### Issue(s):
[Enhancement #4520](https://devtopia.esri.com/WebGIS/arcgis-geoevent/issues/4520)
[Engagement #4519](https://devtopia.esri.com/WebGIS/arcgis-geoevent/issues/4519)

### Description
- Added `headers` and `topic` to the `Exchange Type` allowed values array list.

### Testing
- Tested on GeoEvent Server 11.3 using the AXL sample RabbitMQ Server